### PR TITLE
bugfix - updated kinesis regex for parsing nodejs logs

### DIFF
--- a/logging/.ebextensions/kinesis.config
+++ b/logging/.ebextensions/kinesis.config
@@ -66,7 +66,7 @@ files:
               {
                 "optionName": "LOGTOJSON",
                 "logFormat": "SYSLOG",
-                "matchPattern": "^(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z) - (.+): (.+)",
+                "matchPattern": "^(\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}Z) - (.+?): (.+)",
                 "customFieldNames": [
                   "timestamp",
                   "log_level",


### PR DESCRIPTION
Old Regex which failing to parse certain kind of logs
![image](https://user-images.githubusercontent.com/18161765/75445993-84692c00-598c-11ea-8d7e-8ef5f455ef61.png)

New Regex - handling this bug here
![image](https://user-images.githubusercontent.com/18161765/75446033-9c40b000-598c-11ea-9e6e-29c5d80d766b.png)

